### PR TITLE
Support AllowLongUriLines for /// comments and FileRegex support for MEN002

### DIFF
--- a/src/Menees.Analyzers/Men002LineTooLong.cs
+++ b/src/Menees.Analyzers/Men002LineTooLong.cs
@@ -111,6 +111,11 @@
 
 		private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
 		{
+			if (!this.settings.IsTypeFileNameCandidate(context.Tree.FilePath))
+			{
+				return;
+			}
+
 			if (context.Tree.TryGetText(out SourceText text))
 			{
 				int tabSize = this.settings.TabSize;

--- a/src/Menees.Analyzers/Men002LineTooLong.cs
+++ b/src/Menees.Analyzers/Men002LineTooLong.cs
@@ -161,9 +161,9 @@
 				string scrubbed = lineText.Trim();
 				if (scrubbed.StartsWith("///"))
 				{
-					scrubbed = scrubbed.Substring(2).Trim();
+					scrubbed = scrubbed.Substring(3).Trim();
 				}
-				else if (scrubbed.StartsWith("///"))
+				else if (scrubbed.StartsWith("//"))
 				{
 					scrubbed = scrubbed.Substring(2).Trim();
 				}

--- a/src/Menees.Analyzers/Men002LineTooLong.cs
+++ b/src/Menees.Analyzers/Men002LineTooLong.cs
@@ -3,13 +3,8 @@
 	#region Using Directives
 
 	using System;
-	using System.Collections.Generic;
 	using System.Collections.Immutable;
-	using System.Linq;
-	using System.Threading;
 	using Microsoft.CodeAnalysis;
-	using Microsoft.CodeAnalysis.CSharp;
-	using Microsoft.CodeAnalysis.CSharp.Syntax;
 	using Microsoft.CodeAnalysis.Diagnostics;
 	using Microsoft.CodeAnalysis.Text;
 
@@ -164,7 +159,11 @@
 			{
 				// Ignore if the whole line minus comment delimiters passes Uri.TryCreate(absolute) (e.g., for http or UNC URLs).
 				string scrubbed = lineText.Trim();
-				if (scrubbed.StartsWith("//"))
+				if (scrubbed.StartsWith("///"))
+				{
+					scrubbed = scrubbed.Substring(2).Trim();
+				}
+				else if (scrubbed.StartsWith("///"))
 				{
 					scrubbed = scrubbed.Substring(2).Trim();
 				}

--- a/tests/Menees.Analyzers.Test/Men002UnitTests.cs
+++ b/tests/Menees.Analyzers.Test/Men002UnitTests.cs
@@ -2,11 +2,8 @@
 {
 	#region Using Directives
 
-	using System;
 	using Menees.Analyzers;
-	using Menees.Analyzers.Test;
 	using Microsoft.CodeAnalysis;
-	using Microsoft.CodeAnalysis.CodeFixes;
 	using Microsoft.CodeAnalysis.Diagnostics;
 	using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -40,6 +37,7 @@ namespace Test
 		{
 			// LongUriLines=true
 			// https://www.amazon.com/Brain-Games%C2%AE-Large-Print-Searches/dp/1640304606/ref=sr_1_2?crid=3KP7CV3HBJADN&keywords=big+long+search+text&qid=1645375366&sprefix=big+long+search+text%2Caps%2C72&sr=8-2
+			/// https://www.amazon.com/Brain-Games%C2%AE-Large-Print-Searches/dp/1640304606/ref=sr_1_2?crid=3KP7CV3HBJADN&keywords=big+long+search+text&qid=1645375366&sprefix=big+long+search+text%2Caps%2C72&sr=8-2
 			/* https://www.google.com/maps/place/Yellowstone+National+Park/@44.5854032,-111.0744669,9z/data=!3m1!4b1!4m5!3m4!1s0x5351e55555555555:0xaca8f930348fe1bb!8m2!3d44.427963!4d-110.588455 */
 			/*
 				Brazil weather?


### PR DESCRIPTION
<summary> style comments begin with /// so if the same contains a URI then AllowLongUriLines was not working for it. Eg:

/// <summary>
/// Current version status of VMware Tools running in the guest operating system.
/// https://vdc-download.vmware.com/vmwb-repository/dcr-public/da47f910-60ac-438b-8b9b-6122f4d14524/16b7274a-bf8b-4b4c-a05e-746f2aa93c8c/doc/vim.vm.GuestInfo.ToolsVersionStatus.html.
/// </summary>